### PR TITLE
Make Graphs Prettier / More readable

### DIFF
--- a/config_factory_graph.yaml
+++ b/config_factory_graph.yaml
@@ -37,7 +37,7 @@ NONLOCKEDNODE_COLOR: 'lightblue2'
 LOCKEDNODE_COLOR: 'green'
 # TB: Vertical, LR: Horizontal, BT: Vertical Inverted, RL: Horizontal Inverted
 # [TB, LR, BT, RL]
-ORIENTATION: 'LR'
+ORIENTATION: 'TB'
 # [line, spline, polyline, curved] 
 # don't use ortho it's buggy
 LINE_STYLE: 'spline'

--- a/config_factory_graph.yaml
+++ b/config_factory_graph.yaml
@@ -35,6 +35,8 @@ EDGECOLOR_CYCLE:
 SOURCESINK_COLOR: 'ghostwhite'
 NONLOCKEDNODE_COLOR: 'lightblue2'
 LOCKEDNODE_COLOR: 'green'
+POSITIVE_COLOR: '#859900'
+NEGATIVE_COLOR: '#dc322f'
 # TB: Vertical, LR: Horizontal, BT: Vertical Inverted, RL: Horizontal Inverted
 # [TB, LR, BT, RL]
 ORIENTATION: 'TB'

--- a/config_factory_graph.yaml
+++ b/config_factory_graph.yaml
@@ -43,6 +43,9 @@ ORIENTATION: 'TB'
 # [line, spline, polyline, curved] 
 # don't use ortho it's buggy
 LINE_STYLE: 'spline'
+# Whether to create a new meta node before multi-input/after multi-output ports
+COMBINE_INPUTS: True
+COMBINE_OUTPUTS: True
 
 
 # { These settings are not added to backend yet

--- a/config_factory_graph.yaml
+++ b/config_factory_graph.yaml
@@ -24,14 +24,23 @@ EDGE_FONTSIZE: 10
 GROUP_FONTSIZE: 18
 BACKGROUND_COLOR: '#043742'
 EDGECOLOR_CYCLE:
-  - 'white'
-  - 'orange'
-  - 'yellow'
-  - 'green'
-  - 'violet'
+  - '#b58900' # 'yellow'
+  - '#cb4b16' # 'orange'
+  - '#dc322f' # 'red'
+  - '#d33682' # 'magenta'
+  - '#6c71c4' # 'violet'
+  - '#268bd2' # 'blue'
+  - '#2aa198' # 'cyan'
+  - '#859900' # 'green'
 SOURCESINK_COLOR: 'ghostwhite'
 NONLOCKEDNODE_COLOR: 'lightblue2'
 LOCKEDNODE_COLOR: 'green'
+# TB: Vertical, LR: Horizontal, BT: Vertical Inverted, RL: Horizontal Inverted
+# [TB, LR, BT, RL]
+ORIENTATION: 'LR'
+# [line, spline, polyline, curved] 
+# don't use ortho it's buggy
+LINE_STYLE: 'spline'
 
 
 # { These settings are not added to backend yet

--- a/graphClasses/graph.py
+++ b/graphClasses/graph.py
@@ -1214,6 +1214,13 @@ class Graph:
         if self.graph_config.get('DEBUG_SHOW_EVERY_STEP', False):
             self.outputGraphviz()
 
+    def nodeHasPort(self, node):
+        if node in ['source', 'sink']:
+            return True
+        if re.match(r'^\d+$', node):
+            return True
+        return False
+
     def getOutputPortSide(self):
         dir = self.graph_config['ORIENTATION']
         if dir == 'TB':
@@ -1431,7 +1438,7 @@ class Graph:
         outPort = self.getOutputPortSide()
 
         for io_info, edge_data in self.edges.items():
-            node_from, node_to, ing_name = io_info
+            src_node, dst_node, ing_name = io_info
             ing_quant, kwargs = edge_data['quant'], edge_data['kwargs']
 
             ing_id = self.getIngId(ing_name)
@@ -1445,9 +1452,18 @@ class Graph:
             # Assign ing color if it doesn't already exist
             ing_color = self.getUniqueColor(ing_id)
 
+            src_has_port = self.nodeHasPort(src_node)
+            dst_has_port = self.nodeHasPort(dst_node)
+
+            src_port = f'{src_node}:o_{ing_id}' if src_has_port else src_node
+            dst_port = f'{dst_node}:i_{ing_id}' if dst_has_port else dst_node
+
+            src_port = f'{src_port}:{outPort}'
+            dst_port = f'{dst_port}:{inPort}'
+
             g.edge(
-                f'{node_from}:o_{ing_id}:{outPort}',
-                f'{node_to}:i_{ing_id}:{inPort}',
+                src_port,
+                dst_port,
                 label=f'({quant_label})',
                 fontcolor=ing_color,
                 color=ing_color,

--- a/graphClasses/graph.py
+++ b/graphClasses/graph.py
@@ -1248,8 +1248,14 @@ class Graph:
             self._color_dict[id] = next(self._color_cycler)
         return self._color_dict[id]
 
+    def getPortId(self, ing_name, port_type):
+        normal = re.sub(' ','_', ing_name).lower().strip()
+        return f'{port_type}_{normal}'
+
     def getIngId(self, ing_name):
-        id = re.sub(r'\[.*?\]', '', ing_name).strip()
+        id = ing_name
+        id = re.sub(r'\[.*?\]', '', id)
+        id = id.strip()
         id = re.sub(r' ', '_', id)
         return id.lower()
 
@@ -1319,7 +1325,6 @@ class Graph:
             num_outputs = len(outputs) if outputs is not None else 0
             has_input = num_inputs > 0
             has_output = num_outputs > 0
-            port_size = max(num_inputs, num_outputs)
             
             if not has_input and not has_output:
                 return (False, lab)
@@ -1346,9 +1351,9 @@ class Graph:
                     io.write('<tr>')
                     for cell in line:
                         if port_type:
-                            port_id = self.getIngId(cell)
+                            port_id = self.getPortId(cell, port_type)
                             ing_name = self.getIngLabel(cell)
-                            io.write(f'<td border="1" PORT="{port_type}_{port_id}">{ing_name}</td>')
+                            io.write(f'<td border="1" PORT="{port_id}">{ing_name}</td>')
                         else:
                             io.write(f'<td border="0">{cell}</td>')
                     io.write('</tr>')
@@ -1366,9 +1371,9 @@ class Graph:
                     for cell in line:
                         io.write('<tr>')
                         if port_type:
-                            port_id = self.getIngId(cell)
+                            port_id = self.getPortId(cell, port_type)
                             ing_name = self.getIngLabel(cell)
-                            io.write(f'<td border="1" PORT="{port_type}_{port_id}">{ing_name}</td>')
+                            io.write(f'<td border="1" PORT="{port_id}">{ing_name}</td>')
                         else:
                             io.write(f'<td border="0">{cell}</td>')
                         io.write('</tr>')
@@ -1457,8 +1462,11 @@ class Graph:
             src_has_port = self.nodeHasPort(src_node)
             dst_has_port = self.nodeHasPort(dst_node)
 
-            src_port = f'{src_node}:o_{ing_id}' if src_has_port else src_node
-            dst_port = f'{dst_node}:i_{ing_id}' if dst_has_port else dst_node
+            src_port_name = self.getPortId(ing_name, 'o')
+            dst_port_name = self.getPortId(ing_name, 'i')
+
+            src_port = f'{src_node}:{src_port_name}' if src_has_port else src_node
+            dst_port = f'{dst_node}:{dst_port_name}' if dst_has_port else dst_node
 
             src_port = f'{src_port}:{outPort}' if src_has_port else src_port
             dst_port = f'{dst_port}:{inPort}' if dst_has_port else dst_port

--- a/graphClasses/graph.py
+++ b/graphClasses/graph.py
@@ -1288,19 +1288,22 @@ class Graph:
         edge_style = {
             'fontname': self.graph_config['GENERAL_FONT'],
             'fontsize': str(self.graph_config['EDGE_FONTSIZE']),
+            'dir': 'both',
+            'arrowtail': 'none',
+            'arrowhead': 'none'
         }
         g = graphviz.Digraph(
             engine='dot',
             strict=False, # Prevents edge grouping
             graph_attr={
+                'bgcolor': self.graph_config['BACKGROUND_COLOR'],
                 'splines': self.graph_config['LINE_STYLE'],
                 'rankdir': self.graph_config['ORIENTATION'],
-                'ranksep': '1.0',
+                'ranksep': '1.25',
+                'nodesep': '0.25',
                 # 'overlap': 'scale',
-                'bgcolor': self.graph_config['BACKGROUND_COLOR'],
                 # 'mindist': '0.1',
                 # 'overlap': 'false',
-                'nodesep': '0.1',
             }
         )
 
@@ -1472,15 +1475,22 @@ class Graph:
             dst_port = f'{dst_port}:{inPort}' if dst_has_port else dst_port
 
             port_style = dict(edge_style)
+            
+            angle = 60 if is_vertical else 20
+            dist = 2.5 if is_vertical else 4
+            port_style.update(labeldistance=str(dist), labelangle=str(angle))
+
             if dst_has_port:
-                angle = 60 if is_vertical else 20
-                dist = 2.5 if is_vertical else 3
-                port_style.update(labeldistance=str(dist), labelangle=str(angle))
+                port_style.update(headlabel=f'({quant_label})')
+                port_style.update(arrowhead='normal')
+
+            if src_has_port:
+                port_style.update(taillabel=f'({quant_label})')
+                port_style.update(arrowtail='tee')
 
             g.edge(
                 src_port,
                 dst_port,
-                headlabel=f'({quant_label})',
                 fontcolor=ing_color,
                 color=ing_color,
                 **kwargs,

--- a/graphClasses/graph.py
+++ b/graphClasses/graph.py
@@ -1306,19 +1306,26 @@ class Graph:
                 groups['no-group'].append(repackaged)
 
         def make_record(lab, inputs, outputs):
+            invert = self.graph_config['ORIENTATION'] in ['BT', 'RL']
             if inputs is None and outputs is None:
                 return (False, lab)
             elif inputs is None:
                 lab = '\\n'.join(lab.split('\n'))
                 output_str = '|'.join(outputs)
                 output_str = '{' + output_str + '}' if len(outputs) > 1 else output_str
-                cell_label = '{' + '|'.join([lab ,output_str]) + '}'
+                if invert:
+                    cell_label = '{' + '|'.join([output_str, lab]) + '}'
+                else:
+                    cell_label = '{' + '|'.join([lab ,output_str]) + '}'
                 return (True, cell_label)
             elif outputs is None:
                 lab = '\\n'.join(lab.split('\n'))
                 input_str = '|'.join(inputs)
                 input_str = '{' + input_str + '}' if len(inputs) > 1 else input_str
-                cell_label = '{' + '|'.join([input_str, lab]) + '}'
+                if invert:
+                    cell_label = '{' + '|'.join([lab, input_str]) + '}'
+                else:
+                    cell_label = '{' + '|'.join([input_str, lab]) + '}'
                 return (True, cell_label)
             else:
                 lab = '\\n'.join(lab.split('\n'))
@@ -1326,7 +1333,10 @@ class Graph:
                 output_str = '|'.join(outputs)
                 input_str = '{' + input_str + '}' if len(inputs) > 1 else input_str
                 output_str = '{' + output_str + '}' if len(outputs) > 1 else output_str
-                cell_label = '{' + '|'.join([input_str, lab ,output_str]) + '}'
+                if invert:
+                    cell_label = '{' + '|'.join([output_str, lab, input_str]) + '}'
+                else:
+                    cell_label = '{' + '|'.join([input_str, lab, output_str]) + '}'
                 return (True, cell_label)
 
         def make_port(ing, io_type):

--- a/graphClasses/graph.py
+++ b/graphClasses/graph.py
@@ -1280,7 +1280,6 @@ class Graph:
             'fontsize': str(self.graph_config['NODE_FONTSIZE']),
         }
         edge_style = {
-            'labeldistance': '0',
             'fontname': self.graph_config['GENERAL_FONT'],
             'fontsize': str(self.graph_config['EDGE_FONTSIZE']),
         }
@@ -1436,6 +1435,9 @@ class Graph:
 
         inPort = self.getInputPortSide()
         outPort = self.getOutputPortSide()
+        
+        is_inverted = self.graph_config['ORIENTATION'] in ['BT', 'RL']
+        is_vertical = self.graph_config['ORIENTATION'] in ['TB', 'BT']
 
         for io_info, edge_data in self.edges.items():
             src_node, dst_node, ing_name = io_info
@@ -1458,17 +1460,23 @@ class Graph:
             src_port = f'{src_node}:o_{ing_id}' if src_has_port else src_node
             dst_port = f'{dst_node}:i_{ing_id}' if dst_has_port else dst_node
 
-            src_port = f'{src_port}:{outPort}'
-            dst_port = f'{dst_port}:{inPort}'
+            src_port = f'{src_port}:{outPort}' if src_has_port else src_port
+            dst_port = f'{dst_port}:{inPort}' if dst_has_port else dst_port
+
+            port_style = dict(edge_style)
+            if dst_has_port:
+                angle = 60 if is_vertical else 20
+                dist = 2.5 if is_vertical else 3
+                port_style.update(labeldistance=str(dist), labelangle=str(angle))
 
             g.edge(
                 src_port,
                 dst_port,
-                label=f'({quant_label})',
+                headlabel=f'({quant_label})',
                 fontcolor=ing_color,
                 color=ing_color,
                 **kwargs,
-                **edge_style
+                **port_style
             )
 
         # Output final graph

--- a/graphClasses/graph.py
+++ b/graphClasses/graph.py
@@ -1346,13 +1346,17 @@ class Graph:
             label = kwargs['label'] if 'label' in kwargs else None
             isRecord = False
             newLabel = None
+
+            def unique(sequence):
+                seen = set()
+                return [x for x in sequence if not (x in seen or seen.add(x))]
             
             if node_name == 'source':
-                names = set([name.lower() for src,_,name in self.edges.keys() if src == 'source'])
+                names = unique([name.lower() for src,_,name in self.edges.keys() if src == 'source'])
                 out_ports = [make_port(x, 'o') for x in names]
                 isRecord, newLabel = make_record(label, None, out_ports)
             elif node_name == 'sink':
-                names = set([name.lower() for _,dst,name in self.edges.keys() if dst == 'sink'])
+                names = unique([name.lower() for _,dst,name in self.edges.keys() if dst == 'sink'])
                 in_ports = [make_port(x, 'i') for x in names]
                 isRecord, newLabel = make_record(label, in_ports, None)
             elif re.match(r'^\d+$', node_name):


### PR DESCRIPTION
* Change default rainbow colors to use the 8 solarized accent colors
* Expose line style and rank direction in the configuration file
* Updated Summary
    * (Configurable) Positive/Negative colors for summary values
    * Ingredient Legend colors now match edge colors
* Make machines `record` type nodes instead of `plain/box` nodes
    * Ingredients are added as ports in the `record` node
* Removed ingredient name from the edges, as its present in the ports now, making for less visual clutter
* Combine input nodes with multiple sources into a single node before entering onto a input port, this is done after the graph has been balanced, doesn't affect adjacency.

<details>
<summary>

## Vertical (TB) Graph Example
</summary>

![ptfe](https://user-images.githubusercontent.com/12700106/196022415-3e0949f1-0e2f-4892-bea3-72b35e5cc8b2.png)
</details>
<details>
<summary>

## Horizontal (LR) Graph Example
</summary>

![ptfe](https://user-images.githubusercontent.com/12700106/196022523-b0202f1b-7da3-476f-8013-ae4f4374f1e2.png)
</details>