### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/src/data/loadMachines.py
+++ b/src/data/loadMachines.py
@@ -64,7 +64,7 @@ def recipesFromConfig(project_name, project_folder='projects'):
     # Load config file
     CONFIG_FILE_PATH = Path(project_folder) / f'{project_name}'
     project_name = CONFIG_FILE_PATH.name.split('.')[0]
-    with open(CONFIG_FILE_PATH, 'r') as f:
+    with open(CONFIG_FILE_PATH, 'rb') as f:
         config = yaml.safe_load(f)
 
     user_config_path = Path(__file__).absolute().parent.parent.parent / 'config_factory_graph.yaml'


### PR DESCRIPTION
Support non-Unicode codecs like gbk to give better language compatibility. UnicodeDecodeError occurs when flowchart yaml contains non-Unicode characters.
To give proper result, the user should change GENERAL_FONT, SUMMARY_FONT, and GROUP_FONT in config_factory_graph.yaml to support their language. And to support machine overclock with multilingual machine names, src/gtnh/overclocks.py need a lot of changes, so I didn't bother with it for now.