### PR TITLE
Moved unsolved inside if statement to prevent crash

### DIFF
--- a/src/graph/_solver.py
+++ b/src/graph/_solver.py
@@ -403,10 +403,10 @@ class SympySolver:
                         iterations += 1
                         continue
 
-                unvar = unsolved[0]
-                solution = solve(expr, unvar)
 
                 if len(unsolved) == 1:
+                    unvar = unsolved[0]
+                    solution = solve(expr, unvar)
                     if len(solution) == 1:
                         sval = solution[0]
                         solved_values[unvar] = sval


### PR DESCRIPTION
Move the ``unvar`` and ``solution`` variables in side of the if statement to prevent a crash when using the following config for Integrated Logic Circuits: https://paste.super.fish/p/LT2qXI.yaml

Creating an issue for this crash: Issue #12 