### PR TITLE
Shows recyclable ingredients & Categorizes summary box

### DIFF
--- a/config_factory_graph.yaml
+++ b/config_factory_graph.yaml
@@ -48,6 +48,7 @@ NONLOCKEDNODE_COLOR: 'lightblue2'
 LOCKEDNODE_COLOR: 'green'
 POSITIVE_COLOR: '#859900'
 NEGATIVE_COLOR: '#dc322f'
+RECYCLABLE_COLOR: '#2aa198'
 
 ORIENTATION: 'TB'
 # TB: Vertical, LR: Horizontal, BT: Vertical Inverted, RL: Horizontal Inverted

--- a/src/graph/_postProcessing.py
+++ b/src/graph/_postProcessing.py
@@ -338,20 +338,6 @@ def addSummaryNode(self):
             total_io[ing_id] += direction * quant
             if direction == -1:
                 input_flows[ing_id] += direction * quant
-    # input_edges = self.adj['source']['O']
-    # output_edges = self.adj['sink']['I']
-
-    # ing_names = {self.getIngId(ing_name): self.getIngLabel(ing_name) for _, _, ing_name in chain(input_edges, output_edges)}
-    # input_flows = {
-    #     self.getIngId(ing_name): -sum(self.edges[e]['quant'] for e in edges)
-    #     for ing_name, edges in groupby(input_edges, lambda e: e[2])
-    # }
-    # output_flows = {
-    #     self.getIngId(ing_name): sum(self.edges[e]['quant'] for e in edges)
-    #     for ing_name, edges in groupby(output_edges, lambda e: e[2])
-    # }
-
-    # io_ids = set(input_flows.keys()).union(output_flows.keys())
 
     def canonicalizeFlow(flow):
         # Set to 0 if too small (intended to avoid floating point issues)

--- a/src/graph/_postProcessing.py
+++ b/src/graph/_postProcessing.py
@@ -318,6 +318,7 @@ def addSummaryNode(self):
     # Compute I/O
     total_io = defaultdict(float)
     ing_names = defaultdict(str)
+    input_flows = defaultdict(float)
     for direction in [-1, 1]:
         if direction == -1:
             # Inputs
@@ -335,25 +336,60 @@ def addSummaryNode(self):
 
             ing_names[ing_id] = self.getIngLabel(ing_name)
             total_io[ing_id] += direction * quant
+            if direction == -1:
+                input_flows[ing_id] += direction * quant
+    # input_edges = self.adj['source']['O']
+    # output_edges = self.adj['sink']['I']
+
+    # ing_names = {self.getIngId(ing_name): self.getIngLabel(ing_name) for _, _, ing_name in chain(input_edges, output_edges)}
+    # input_flows = {
+    #     self.getIngId(ing_name): -sum(self.edges[e]['quant'] for e in edges)
+    #     for ing_name, edges in groupby(input_edges, lambda e: e[2])
+    # }
+    # output_flows = {
+    #     self.getIngId(ing_name): sum(self.edges[e]['quant'] for e in edges)
+    #     for ing_name, edges in groupby(output_edges, lambda e: e[2])
+    # }
+
+    # io_ids = set(input_flows.keys()).union(output_flows.keys())
+
+    def canonicalizeFlow(flow):
+        # Set to 0 if too small (intended to avoid floating point issues)
+        return flow if abs(flow) > 1e-5 else 0
+    total_io = {ing: canonicalizeFlow(flow) for ing, flow in total_io.items()}
 
     # Create I/O lines
     io_label_lines = []
-    io_label_lines.append(f'<tr><td align="left"><font color="white" face="{self.graph_config["SUMMARY_FONT"]}"><b>Summary</b></font></td></tr><hr/>')
 
-    for id, quant in sorted(total_io.items(), key=lambda x: x[1]):
-        if id == 'eu':
-            continue
+    def makeIOTitle(title):
+        font = self.graph_config["SUMMARY_FONT"]
+        return f'<tr><td align="left"><font color="white" face="{font}"><b>{title}</b></font></td></tr><hr/>'
 
-        # Skip if too small (intended to avoid floating point issues)
-        near_zero_range = 10**-5
-        if -near_zero_range < quant < near_zero_range:
-            continue
+    def makeIOLines(flows, color):
+        for id, quant in sorted(flows, key=lambda x: -abs(x[1])):
+            amt_text = self.getQuantLabel(id, quant)
+            name_text = '\u2588 ' + ing_names[id]
+            num_color = color
+            ing_color = self.getUniqueColor(id)
+            yield makeLineHtml(name_text, amt_text, ing_color, num_color)
 
-        amt_text = self.getQuantLabel(id, quant)
-        name_text = '\u2588 ' + ing_names[id]
-        num_color = color_positive if quant >= 0 else color_negative
-        ing_color = self.getUniqueColor(id)
-        io_label_lines.append(makeLineHtml(name_text, amt_text, ing_color, num_color))
+    ## If one ingredient's net output is equal or greater than 0, it is recyclable
+    recyclable_flows = {id: quant for id, quant in total_io.items() if id != 'eu' and input_flows.get(id, 0) < 0 and total_io[id] >= 0}
+    color_recyclable = self.graph_config['RECYCLABLE_COLOR']
+    io_label_lines.append(makeIOTitle('Input'))
+    io_label_lines.extend(makeIOLines(
+        filter(lambda e: e[0] != 'eu' and e[0] not in recyclable_flows and e[1] < 0, total_io.items()),
+        color_negative
+    ))
+    io_label_lines.append(makeIOTitle('Output'))
+    io_label_lines.extend(makeIOLines(
+        filter(lambda e: e[0] != 'eu' and e[0] not in recyclable_flows and e[1] > 0, total_io.items()),
+        color_positive
+    ))
+    ## There might not be recyclable inputs
+    if recyclable_flows:
+        io_label_lines.append(makeIOTitle('Recyclable'))
+        io_label_lines.extend(makeIOLines(recyclable_flows.items(), color_recyclable))
 
     # Compute total EU/t cost and (if power line) output
     total_eut = 0


### PR DESCRIPTION
1. Shows recyclable ingredients in the summary box. Before it was kinda hard to see which ingredients are recyclable.
2. Categorizes the box into 3 categories: input, output and recyclable.
3. Sorts by amount from high to low in each category. Before inputs were sorted from high to low, and outputs were from low to high.

How it decides which ingredient is recyclable: 
- first, the item/fluid should be present in the inputs, i.e. its input flow <0; 
- secondly, its net flow through the system, i.e. its value in `total_io`, can either =0 or >0. This means if the system outputs that ingredient more than it gets, the ingredient is also deemed recyclable.

![image](https://github.com/OrderedSet86/gtnh-flow/assets/9444155/77504525-ba65-4f1d-81d8-4bab8a2cd7ba)

![image](https://github.com/OrderedSet86/gtnh-flow/assets/9444155/8eee205b-65e0-4ba4-a60b-ef47cc2556f9)

Tested with this project file (bauxite line):
<details>

<summary>Click to expand</summary>

```yaml
- m: mixer
  group: bauxite
  # circuit 8
  tier: hv  # mv recipe
  I:
    purified bauxite ore: 32
    sodium hydroxide dust: 9
    quicklime dust: 4
    water: 5000
  O:
    bauxite slurry: 8000
  eut: 120
  dur: 10
- m: oil cracker
  group: bauxite
  # circuit 1
  tier: hv  # hv recipe
  I:
    steam: 2000
    bauxite slurry: 32000
  O:
    heated bauxite slurry: 32000
  eut: 400
  dur: 8
- m: lcr
  group: bauxite
  # no circuit
  tier: hv  # hv recipe
  I:
    aluminum hydroxide dust: 1
    co2 gas: 5000
    heated bauxite slurry: 8000
  O:
    alumina dust: 80
    '[na recycle] sodium carbonate dust': 9
    '[ca recycle] calcite dust': 10
    bauxite slag: 16
    sluice juice: 5000
  eut: 480
  dur: 15
  number: 1
- m: industrial centrifuge
  group: bauxite
  tier: hv  # mv recipe
  I:
    bauxite slag: 1
  O:
    rutile dust: 1
    gallium dust: 0.3
    quicklime dust: 0.2
    silicon dioxide dust: 0.9
    iron dust: 0.8
  eut: 120
  dur: 2

# ==== Al(OH)3 ====
- m: mixer
  group: al(oh)3
  # circuit 1
  tier: hv  # mv recipe
  I:
    purified ruby dust: 1
    tiny pile of naoh: 1
    hcl: 1000
  O:
    ruby juice: 1000
  eut: 100
  dur: 2
- m: industrial centrifuge
  group: al(oh)3
  # circuit 1
  tier: hv  # mv recipe
  I:
    ruby juice: 1000
  O:
    aluminum hydroxide dust: 3
    chrome dust: 1
    iron dust: 1
    vanadium dust: 1
    magnesium dust: 1
    '[recycle] hcl': 1000
  eut: 100
  dur: 2.25
# ==== End of Al(OH)3 ====

# ==== Sluice Juice ====
- m: distillery
  group: sluice juice
  tier: hv  # lv recipe
  # circuit 1
  I:
    sluice juice: 1000
  O:
    sluice sand dust: 1
    '[recycle] water': 500
  eut: 16
  dur: 5
- m: electromagnetic separator
  group: sluice juice
  tier: hv  # hv recipe
  I:
    sluice sand dust: 1
  O:
    iron dust: 0.4
    neodymium dust: 0.2
    chrome dust: 0.2
  eut: 240
  dur: 10
# ==== End of Sluice Juice ====

# ==== Recycle Calcium ====
- m: industrial electrolyzer
  group: recycle calcium
  tier: hv  # mv recipe
  I:
    '[ca recycle] calcite dust': 5
  O:
    calcium dust: 1
    carbon dust: 1
    '[recycle] oxygen': 3000
  eut: 60
  dur: 5
- m: lcr
  group: recycle calcium
  # circuit 1
  tier: hv  # lv recipe
  I:
    calcium dust: 1
    oxygen: 1000
  O:
    '[recycle] quicklime dust': 2
  eut: 30
  dur: 0.5
# ==== End of Recycle NaOH ====

# ==== Recycle Sodium ====
- m: industrial electrolyzer
  group: recycle sodium
  tier: hv  # mv recipe
  I:
    '[na recycle] sodium carbonate dust': 6
  O:
    sodium dust: 2
    carbon dust: 1
    '[recycle] oxygen': 3000
  eut: 60
  dur: 4.8
- m: lcr
  group: recycle sodium
  # circuit 1
  tier: hv  # lv recipe
  I:
    sodium dust: 1
    water: 1000
  O:
    '[recycle] sodium hydroxide dust': 3
    hydrogen: 1000
  eut: 30
  dur: 10
# ==== End of Recycle Sodium ====
```
</details>