### PR TITLE
Colors node boxes by machine type

### DIFF
--- a/config_factory_graph.yaml
+++ b/config_factory_graph.yaml
@@ -49,17 +49,45 @@ LOCKEDNODE_COLOR: 'green'
 POSITIVE_COLOR: '#859900'
 NEGATIVE_COLOR: '#dc322f'
 RECYCLABLE_COLOR: '#2aa198'
+# Find color codes at: https://graphviz.org/doc/info/colors.html
+# Trying to pick one similar to the color of multis, but
+# there are some exceptions like
+# LPF machines and mixer share the same multi-use casings
+DEFAULT_MACHINE_COLOR: aliceblue
+MACHINE_COLORS:
+  electric blast furnace: lightgreen
+  volcanus: lightgreen
+  chemical reactor: dimgrey
+  large chemical reactor: dimgrey
+  distillery: lightblue1
+  distillation tower: lightblue1
+  dangote: lightblue1
+  centrifuge: goldenrod2
+  industrial centrifuge: goldenrod2
+  electrolyzer: lightsalmon2
+  industrial electrolyzer: lightsalmon2
+  autoclave: slateblue3
+  vacuum freezer: royalblue1
+  cryogenic freezer: royalblue1
+  ore washing plant: teal
+  macerator: peru
+  maceration stack: peru
+  industrial dehydrator: tomato3
+  dehydrator: tomato3
+  alloy blast smelter: wheat3
+  industrial sledgehammer: seagreen4
+  forge hammer: seagreen4
 
 ORIENTATION: 'TB'
 # TB: Vertical, LR: Horizontal, BT: Vertical Inverted, RL: Horizontal Inverted
 # [TB, LR, BT, RL]
 
 LINE_STYLE: 'spline'
-# [line, spline, polyline, curved] 
+# [line, spline, polyline, curved]
 
 RANKSEP: '1.25'
 NODESEP: '0.25'
-# Node separation size in X/Y. 
+# Node separation size in X/Y.
 # This is a suggestion, the graphing algorithm will ignore numbers that are too small.
 
 COMBINE_INPUTS: true

--- a/src/graph/_postProcessing.py
+++ b/src/graph/_postProcessing.py
@@ -105,8 +105,9 @@ def addUserNodeColor(self):
 
     for rec_id in all_user_nodes:
         # Emphasizes the first line (i.e. machine name line)
-        self.nodes[rec_id]['label'] = re.sub(r'^([^\n]+)', r'<b><u>\1</u></b>', self.nodes[rec_id]['label'])
-
+        lines = self.nodes[rec_id]['label'].split('\n')
+        lines[0] = r'<b><u>' + lines[0] + r'</u></b>'
+        self.nodes[rec_id]['label'] = '\n'.join(lines)
 
 
 def addMachineMultipliers(self):

--- a/src/graph/_postProcessing.py
+++ b/src/graph/_postProcessing.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import re
 from collections import defaultdict
 from copy import deepcopy
 from string import ascii_uppercase
@@ -21,7 +22,7 @@ def capitalizeMachine(machine):
     capitalization_exceptions = {
         # Format is old_str: new_str
     }
-    
+
     if len(machine_capitals) > 0:
         return machine
     elif machine in capitalization_exceptions:
@@ -38,7 +39,7 @@ def createMachineLabels(self):
     # Cycle: 2.0s
     # Amoritized: 1.46K EU/t
     # Per Machine: 256EU/t
-    
+
     for node_id in self.nodes:
         if self._checkIfMachine(node_id):
             rec_id = node_id
@@ -78,7 +79,7 @@ def createMachineLabels(self):
         if rec.machine in recognized_basic_power_machines:
             # Remove power input data
             label_lines = label_lines[:-2]
-        
+
         line_if_attr_exists = {
             'heat': (lambda rec: f'Base Heat: {rec.heat}K'),
             'coils': (lambda rec: f'Coils: {rec.coils.title()}'),
@@ -103,14 +104,15 @@ def addUserNodeColor(self):
     all_user_nodes = set(targeted_nodes) | set(numbered_nodes)
 
     for rec_id in all_user_nodes:
-        self.nodes[rec_id].update({'fillcolor': self.graph_config['LOCKEDNODE_COLOR']})
+        # Emphasizes the first line (i.e. machine name line)
+        self.nodes[rec_id]['label'] = re.sub(r'^([^\n]+)', r'<b><u>\1</u></b>', self.nodes[rec_id]['label'])
 
 
 
 def addMachineMultipliers(self):
     # Compute machine multiplier based on solved ingredient quantities
     # FIXME: If multipliers disagree, sympy solver might have failed on an earlier step
-    
+
     for rec_id, rec in self.recipes.items():
         multipliers = []
 
@@ -127,7 +129,7 @@ def addMachineMultipliers(self):
                         solved_quant_per_s += self.edges[edge]['quant']
 
                 base_quant_s = base_quant / (rec.dur/20)
-                
+
                 # print(io_dir, rec_id, ing_name, getattr(rec, io_dir))
                 # print(solved_quant_per_s, base_quant_s, rec.dur)
                 # print()
@@ -257,7 +259,7 @@ def addPowerLineNodesV2(self):
                 wasted_fuel=f'{self.userRound(loss_on_singleblock_output)}EU/t/amp',
             )
 
-            produced_eut_s = quant_s/expended_fuel_t*output_eut 
+            produced_eut_s = quant_s/expended_fuel_t*output_eut
             self.parent_context.log.info(
                 colored(
                     ''.join([
@@ -270,7 +272,7 @@ def addPowerLineNodesV2(self):
 
             self.addNode(
                 node_idx,
-                fillcolor=self.graph_config['NONLOCKEDNODE_COLOR'],
+                fillcolor=self.graph_config['DEFAULT_MACHINE_COLOR'],
                 shape='box'
             )
 
@@ -310,7 +312,7 @@ def addSummaryNode(self):
 
     color_positive = self.graph_config['POSITIVE_COLOR']
     color_negative = self.graph_config['NEGATIVE_COLOR']
-    
+
     def makeLineHtml(lab_text, amt_text, lab_color, amt_color):
         return ''.join([
             '<tr>'
@@ -433,8 +435,8 @@ def addSummaryNode(self):
         max_draw += rec.base_eut * math.ceil(rec.multiplier)
 
     io_label_lines.append(
-        makeLineHtml( 
-            'Peak power draw:', 
+        makeLineHtml(
+            'Peak power draw:',
             f'{round(max_draw/voltage_at_tier, 2)}A {tiers[max_tier].upper()}',
             'white',
             color_negative

--- a/src/graph/_preProcessing.py
+++ b/src/graph/_preProcessing.py
@@ -45,12 +45,14 @@ def connectGraph(self):
                 machine_label.append(line_generator(rec))
 
         machine_label = '\n'.join(machine_label)
+        machine_color = self.graph_config['MACHINE_COLORS'].get(
+            rec.machine, self.graph_config['DEFAULT_MACHINE_COLOR'])
         self.addNode(
             rec_id,
-            fillcolor=self.graph_config['NONLOCKEDNODE_COLOR'],
+            fillcolor=machine_color,
             label=machine_label
         )
-    
+
     # Add I/O connections
     added_edges = set()
     for rec_id, rec in self.recipes.items():
@@ -135,4 +137,3 @@ def removeBackEdges(self):
             )
 
             del self.edges[edge_def]
-

--- a/tests/sanity_config.yaml
+++ b/tests/sanity_config.yaml
@@ -43,22 +43,23 @@ EDGECOLOR_CYCLE:
   - '#2aa198' # 'cyan'
   - '#859900' # 'green'
 SOURCESINK_COLOR: 'ghostwhite'
-NONLOCKEDNODE_COLOR: 'lightblue2'
-LOCKEDNODE_COLOR: 'green'
 POSITIVE_COLOR: '#859900'
 NEGATIVE_COLOR: '#dc322f'
 RECYCLABLE_COLOR: '#2aa198'
+DEFAULT_MACHINE_COLOR: aliceblue
+MACHINE_COLORS:
+  electric blast furnace: aliceblue
 
 ORIENTATION: 'TB'
 # TB: Vertical, LR: Horizontal, BT: Vertical Inverted, RL: Horizontal Inverted
 # [TB, LR, BT, RL]
 
 LINE_STYLE: 'spline'
-# [line, spline, polyline, curved] 
+# [line, spline, polyline, curved]
 
 RANKSEP: '1.25'
 NODESEP: '0.25'
-# Node separation size in X/Y. 
+# Node separation size in X/Y.
 # This is a suggestion, the graphing algorithm will ignore numbers that are too small.
 
 COMBINE_INPUTS: true


### PR DESCRIPTION
part of #27. Only add color to some machines.

1. Emphasizes the font of the targeted machine name instead of giving it a special color
2. Colors are configurable for each machine. There is also a default color configuration.
3. Changes sanity config to pass sanity tests

Potential improvement: do not colorize machine input/output boxes to make them more clear

Example:
![tungsten_tungstate-dust](https://github.com/OrderedSet86/gtnh-flow/assets/9444155/98e2f779-a071-48e6-97ad-7e3ecc91b499)

