### PR TITLE
Fixes case sensitivity in some recipe inputs

### DIFF
--- a/data/overclock_data.yaml
+++ b/data/overclock_data.yaml
@@ -22,8 +22,8 @@ coil_heat:
   nichrome: 3601
   tungstensteel: 4501
   tpv-alloy: 4501
-  HSS-G: 5401
-  HSS-S: 6301
+  hss-g: 5401
+  hss-s: 6301
   naquadah: 7201
   naquadah alloy: 8101
   trinium: 9001
@@ -32,7 +32,7 @@ coil_heat:
   infinity: 11701
   hypogen: 12601
   eternal: 13501
-  
+
 
 pipe_casings:
   bronze: 2

--- a/src/data/basicTypes.py
+++ b/src/data/basicTypes.py
@@ -48,7 +48,7 @@ class IngredientCollection:
     def addItem(self, item: Ingredient):
         self._ings.append(item)
         self._ingdict[item.name].append(item.quant)
-    
+
     def __add__(self, other: 'IngredientCollection'):
         for ing in other:
             self.addItem(ing)
@@ -75,6 +75,10 @@ class Recipe:
         self.multiplier = -1
         self.base_eut = eut # Used for final graph output
         for key, value in kwargs.items():
+            # quick fix to ignore cases
+            # this implies that config files better use lower-case too
+            if type(value) is str:
+                value = value.lower()
             setattr(self, key, value)
 
     def __repr__(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,63 @@
+import pytest
+
+from factory_graph import ProgramContext
+from src.data.basicTypes import Ingredient as Ing
+from src.data.basicTypes import IngredientCollection as IngCol
+from src.data.basicTypes import Recipe
+from src.gtnh.overclocks import OverclockHandler
+
+
+@pytest.fixture
+def overclock_handler():
+    # for now it uses config file in the project
+    # it may cause issue if config file is messed up
+    return OverclockHandler(ProgramContext())
+
+
+@pytest.mark.parametrize(
+    "coils",
+    [
+        "cupronickel",
+        "Cupronickel",
+        "hss-g",
+        "HSS-G",
+    ],
+)
+def test_coils_value_case_sensitivity(coils, overclock_handler):
+    recipe = Recipe(
+        "electric blast furnace",
+        "ev",
+        IngCol(Ing("galena dust", 9), Ing("oxygen gas", 27000)),
+        IngCol(Ing("roasted lead dust", 9), Ing("ashes", 1), Ing("so2", 9000)),
+        120,
+        54,
+        coils=coils,
+        heat=1200,
+    )
+
+    # tests pass if no exceptions are thrown
+    overclock_handler.overclockRecipe(recipe)
+
+
+@pytest.mark.parametrize(
+    "saw",
+    [
+        "saw",
+        "Saw",
+        "buzzsaw",
+        "BuzzSaw",
+    ],
+)
+def test_saw_value_case_sensitivity(saw, overclock_handler):
+    recipe = Recipe(
+        "tree growth simulator",
+        "lv",
+        IngCol(),
+        IngCol(Ing("oak wood", 5)),
+        32,
+        5,
+        saw_type=saw,
+    )
+
+    # tests pass if no exceptions are thrown
+    overclock_handler.overclockRecipe(recipe)

--- a/tests/test_overclocks.py
+++ b/tests/test_overclocks.py
@@ -18,6 +18,8 @@ def mod_recipe(recipe, **kwargs):
 
 @pytest.fixture
 def overclock_handler():
+    # for now it uses config file in the project
+    # it may cause issue if config file is messed up
     return OverclockHandler(ProgramContext())
 
 


### PR DESCRIPTION
The issue was that "hss-g" won't be recognized. I had to put "HSS-G". This PR makes all string-type "extra" fields in recipes case insensitive. "Extra" means the kwargs passed into Recipe constructor.

The side effect is that related values in configs and internal constants need to be case insensitive too. I chose to make "HSS-G" etc. lowercase in config files, since all other values in that file use lower cases