### PR TITLE
Adds an optional "nc" field for all "Not Consumed" input

### DIFF
--- a/src/graph/_postProcessing.py
+++ b/src/graph/_postProcessing.py
@@ -81,6 +81,7 @@ def createMachineLabels(self):
             label_lines = label_lines[:-2]
 
         line_if_attr_exists = {
+            'nc': (lambda rec: f'NC: {rec.nc.title()}'),
             'heat': (lambda rec: f'Base Heat: {rec.heat}K'),
             'coils': (lambda rec: f'Coils: {rec.coils.title()}'),
             'saw_type': (lambda rec: f'Saw Type: {rec.saw_type.title()}'),


### PR DESCRIPTION
Was thinking about adding "circuit" field, but there are too many kinds of "not consumed" input ingredients in various recipes, not just circuits. Basically this is a field solely for notes, and users can put any string in this field. It doesn't (shouldn't) affect overclock calculation, unlike Chem Plant's catalyst field, for example.

Tested with

```yaml
- m: ebf
  tier: ev
  I:
    iron dust: 1
    oxygen gas: 1000
  O:
    steel ingot: 1
    tiny piles of ashes: 1
  nc: "programmed circuit #11"
  circuit: 4
  heat: 1000
  coils: cupronickel
  eut: 120
  dur: 25
  number: 1
```

Output:

![image](https://github.com/OrderedSet86/gtnh-flow/assets/9444155/1d4d2188-c55c-4c42-a4c2-231295ec7d1f)
