### PR TITLE
Fix a chem plant naming issue

### DIFF
--- a/src/gtnh/overclocks.py
+++ b/src/gtnh/overclocks.py
@@ -475,7 +475,7 @@ class OverclockHandler:
             # Special GT++ multis
             'dangote - distillation tower': lambda rec: self.modifyGTpp(rec, MAX_PARALLEL=12),
             'industrial coke oven': self.modifyICO,
-            'chem plant': self.modifyChemPlant,
+            'chemical plant': self.modifyChemPlant,
             'zhuhai': self.modifyZhuhai,
             'tree growth simulator': self.modifyTGS,
             'industrial dehydrator': self.modifyUtupu,


### PR DESCRIPTION
Most naming stuff was fixed in https://github.com/OrderedSet86/gtnh-flow/commit/238f72a382af14282d4d37ad3277cc04010551ef, but it looks like this got missed. It causes chem plant calculations to fall back on the standard oc.